### PR TITLE
Show full SSID, even with blanks

### DIFF
--- a/scripts/wifi_ssid.sh
+++ b/scripts/wifi_ssid.sh
@@ -5,7 +5,7 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/helpers.sh"
 
 wifi_ssid() {
-  airport_status | grep -e '\bSSID:\B' | awk '{print $2}'
+  airport_status | grep -e '\bSSID:\B' | awk '{for(i=n;i<=NF;i++)$(i-(n-1))=$i;NF=NF-(n-1);print $0}' n=2
 }
 
 main() {


### PR DESCRIPTION
* When SSID containes spaces, wifi_ssid.sh cuts the SSID at the first
  space. Changed awk expression to handle this correctly.